### PR TITLE
Make HBB and HBI partitions readOnly

### DIFF
--- a/p9Layouts/defaultPnorLayout_128.xml
+++ b/p9Layouts/defaultPnorLayout_128.xml
@@ -155,6 +155,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +174,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <pnorOnly/>
         <ecc/>
     </section>
     <section>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -155,6 +155,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +174,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>


### PR DESCRIPTION
Sets the readOnly tag for HBB and HBI partitions in the hostboot
pnor for both the 64mb and 128mb pnor layouts.