### PR TITLE
Make HBB and HBI partitions readOnly

### DIFF
--- a/p9Layouts/defaultPnorLayout_128.xml
+++ b/p9Layouts/defaultPnorLayout_128.xml
@@ -62,6 +62,7 @@ Layout Description
                        but is across reboots. BMC will clear on power off/on
     <clearOnEccErr/>-> Indication that if an ECC error is comsumed on this partition,
                        clear (write 0xFF with good ECC) to the partition to recover
+    <readOnly/>     -> Indicates that the partition will be marked read only.
 </section>
 -->
 
@@ -155,6 +156,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +175,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -199,7 +199,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (4.5MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x1381000</physicalOffset>
+        <physicalOffset>0x14A1000</physicalOffset>
         <physicalRegionSize>0x480000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -303,7 +303,7 @@ Layout Description
     <section>
         <description>IMA Catalog (256K)</description>
         <eyeCatch>IMA_CATALOG</eyeCatch>
-        <physicalOffset>0x2A88000</physicalOffset>
+        <physicalOffset>0x2A89000</physicalOffset>
         <physicalRegionSize>0x40000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -62,6 +62,7 @@ Layout Description
                        but is across reboots. BMC will clear on power off/on
     <clearOnEccErr/>-> Indication that if an ECC error is comsumed on this partition,
                        clear (write 0xFF with good ECC) to the partition to recover
+    <readOnly/>     -> Indicates that the partition will be marked read only.
 </section>
 -->
 
@@ -155,6 +156,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +175,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>

--- a/update_image.pl
+++ b/update_image.pl
@@ -292,8 +292,8 @@ sub processConvergedSections {
         print "WARNING: MEMD partition is not found, including blank binary instead\n";
     }
     $sections{MEMD}{out}       = "$scratch_dir/memd_extra_data.bin.ecc";
-   
-    # SMC COPY SAME ideas for hdat 
+
+    # SMC COPY SAME ideas for hdat
     if(-e $hdat_binary_filename)
     {
         $sections{HDAT}{in}    = "$hdat_binary_filename";
@@ -358,7 +358,6 @@ sub processConvergedSections {
         # Point to the location of the signing tools
         $ENV{'DEV_KEY_DIR'}="$ENV{'HOST_DIR'}/etc/keys/";
         $ENV{'SIGNING_DIR'} = "$ENV{'HOST_DIR'}/usr/bin/";
-        $ENV{'SIGNING_TOOL_EDITION'} = "community";
 
         # Determine whether to securely sign the images
         my $securebootArg = $secureboot ? "--secureboot" : "";
@@ -382,8 +381,6 @@ sub processConvergedSections {
         {
             print STDOUT "SIGNING_DIR: " . $ENV{'SIGNING_DIR'} . "\n";
             print STDOUT "DEV_KEY_DIR: " . $ENV{'DEV_KEY_DIR'} . "\n";
-            print STDOUT "SIGNING_TOOL_EDITION: "
-                . $ENV{'SIGNING_TOOL_EDITION'} . "\n";
         }
 
         run_command($cmd);
@@ -489,7 +486,7 @@ else
     # Create blank binary file for ATTR_TMP partition
     run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
     run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_tmp.bin.ecc --p8");
-    
+
     # Create blank binary file for ATTR_PERM partition
     run_command("dd if=/dev/zero bs=28K count=1 | tr \"\\000\" \"\\377\" > $scratch_dir/hostboot.temp.bin");
     run_command("ecc --inject $scratch_dir/hostboot.temp.bin --output $scratch_dir/attr_perm.bin.ecc --p8");


### PR DESCRIPTION
Sets the readOnly tag for HBB and HBI partitions in the hostboot
pnor for both the 64mb and 128mb pnor layouts.