### PR TITLE
Make HBB and HBI partitions readOnly

### DIFF
--- a/p9Layouts/defaultPnorLayout_128.xml
+++ b/p9Layouts/defaultPnorLayout_128.xml
@@ -62,6 +62,7 @@ Layout Description
                        but is across reboots. BMC will clear on power off/on
     <clearOnEccErr/>-> Indication that if an ECC error is comsumed on this partition,
                        clear (write 0xFF with good ECC) to the partition to recover
+    <readOnly/>     -> Indicates that the partition will be marked read only.
 </section>
 -->
 
@@ -155,6 +156,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +175,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -199,7 +199,7 @@ Layout Description
     <section>
         <description>Hostboot Runtime Services for Sapphire (4.5MB)</description>
         <eyeCatch>HBRT</eyeCatch>
-        <physicalOffset>0x1381000</physicalOffset>
+        <physicalOffset>0x14A1000</physicalOffset>
         <physicalRegionSize>0x480000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
@@ -303,7 +303,7 @@ Layout Description
     <section>
         <description>IMA Catalog (256K)</description>
         <eyeCatch>IMA_CATALOG</eyeCatch>
-        <physicalOffset>0x2A88000</physicalOffset>
+        <physicalOffset>0x2A89000</physicalOffset>
         <physicalRegionSize>0x40000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -62,6 +62,7 @@ Layout Description
                        but is across reboots. BMC will clear on power off/on
     <clearOnEccErr/>-> Indication that if an ECC error is comsumed on this partition,
                        clear (write 0xFF with good ECC) to the partition to recover
+    <readOnly/>     -> Indicates that the partition will be marked read only.
 </section>
 -->
 
@@ -155,6 +156,7 @@ Layout Description
         <physicalRegionSize>0x100000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>
@@ -173,6 +175,7 @@ Layout Description
         <physicalRegionSize>0xEA0000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
         <ecc/>
     </section>
     <section>


### PR DESCRIPTION
Sets the readOnly tag for HBB and HBI partitions in the hostboot
pnor for both the 64mb and 128mb pnor layouts.

Signed-off-by: Jaymes Wilks <mjwilks@us.ibm.com>