### PR TITLE
Support to split ATTR PNOR Partition into RO and RW Partitions

### DIFF
--- a/create_pnor_image.pl
+++ b/create_pnor_image.pl
@@ -14,6 +14,8 @@ my $bootkernel = "";
 my $hb_image_dir = "";
 my $xml_layout_file = "";
 my $targeting_binary_filename = "";
+my $targeting_RO_binary_filename = "";
+my $targeting_RW_binary_filename = "";
 my $sbec_binary_filename = "";
 my $sbe_binary_filename = "";
 my $wink_binary_filename = "";
@@ -72,6 +74,14 @@ while (@ARGV > 0){
         $targeting_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a targeting binary filename.\n";
         shift;
     }
+    elsif (/^-targeting_RO_binary_filename/i){
+        $targeting_RO_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a targeting binary filename.\n";
+        shift;
+    }
+    elsif (/^-targeting_RW_binary_filename/i){
+        $targeting_RW_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a targeting binary filename.\n";
+        shift;
+    }
     elsif (/^-sbe_binary_filename/i){
         $sbe_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting an sbe binary filename.\n";
         shift;
@@ -125,7 +135,8 @@ print "pnor_data_dir = $pnor_data_dir\n";
 
 my $build_pnor_command = "$hb_image_dir/buildpnor.pl";
 $build_pnor_command .= " --pnorOutBin $pnor_filename --pnorLayout $xml_layout_file";
-$build_pnor_command .= " --binFile_HBD $scratch_dir/$targeting_binary_filename";
+$build_pnor_command .= " --binFile_HBD_RO $scratch_dir/$targeting_RO_binary_filename";
+$build_pnor_command .= " --binFile_HBD_RW $scratch_dir/$targeting_RW_binary_filename";
 $build_pnor_command .= " --binFile_SBE $scratch_dir/$sbe_binary_filename";
 $build_pnor_command .= " --binFile_HBB $scratch_dir/hostboot.header.bin.ecc";
 $build_pnor_command .= " --binFile_HBI $scratch_dir/hostboot_extended.header.bin.ecc";

--- a/p9Layouts/defaultPnorLayout_64.xml
+++ b/p9Layouts/defaultPnorLayout_64.xml
@@ -160,12 +160,21 @@ Layout Description
         <ecc/>
     </section>
     <section>
-        <description>Hostboot Data (1.125M)</description>
-        <eyeCatch>HBD</eyeCatch>
+        <description>Hostboot Data - READ-ONLY (~819KB)</description>
+        <eyeCatch>HBD_RO</eyeCatch>
         <physicalOffset>0x305000</physicalOffset>
-        <physicalRegionSize>0x120000</physicalRegionSize>
+        <physicalRegionSize>0xFC000</physicalRegionSize>
         <side>A</side>
         <sha512Version/>
+        <readOnly/>
+        <ecc/>
+    </section>
+    <section>
+        <description>Hostboot Data - Read-Write (~333KB)</description>
+        <eyeCatch>HBD_RW</eyeCatch>
+        <physicalOffset>0x401000</physicalOffset>
+        <physicalRegionSize>0x24000</physicalRegionSize>
+        <side>A</side>
         <ecc/>
     </section>
     <section>

--- a/update_image.pl
+++ b/update_image.pl
@@ -13,6 +13,10 @@ my $hb_binary_dir = "";
 my $sbe_binary_dir = "";
 my $targeting_binary_filename = "";
 my $targeting_binary_source = "";
+my $targeting_RO_binary_filename = "";
+my $targeting_RO_binary_source = "";
+my $targeting_RW_binary_filename = "";
+my $targeting_RW_binary_source = "";
 my $sbe_binary_filename = "";
 my $sbec_binary_filename = "";
 my $wink_binary_filename = "";
@@ -72,6 +76,22 @@ while (@ARGV > 0){
     }
     elsif (/^-targeting_binary_source/i){
         $targeting_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RO_binary_filename/i){
+        $targeting_RO_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RO_binary_source/i){
+        $targeting_RO_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RW_binary_filename/i){
+        $targeting_RW_binary_filename = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
+        shift;
+    }
+    elsif (/^-targeting_RW_binary_source/i){
+        $targeting_RW_binary_source = $ARGV[1] or die "Bad command line arg given: expecting a config type.\n";
         shift;
     }
     elsif (/^-sbe_binary_filename/i){
@@ -235,8 +255,10 @@ sub processConvergedSections {
     $sections{HBB}{out}         = "$scratch_dir/hostboot.header.bin.ecc";
     $sections{HBI}{in}          = "$hb_image_dir/img/hostboot_extended.bin";
     $sections{HBI}{out}         = "$scratch_dir/hostboot_extended.header.bin.ecc";
-    $sections{HBD}{in}          = "$op_target_dir/$targeting_binary_source";
-    $sections{HBD}{out}         = "$scratch_dir/$targeting_binary_filename";
+    $sections{HBD_RO}{in}       = "$op_target_dir/$targeting_RO_binary_source";
+    $sections{HBD_RO}{out}      = "$scratch_dir/$targeting_RO_binary_filename";
+    $sections{HBD_RW}{in}       = "$op_target_dir/$targeting_RW_binary_source";
+    $sections{HBD_RW}{out}      = "$scratch_dir/$targeting_RW_binary_filename";
     $sections{SBE}{in}          = "$sbePreEcc";
     $sections{SBE}{out}         = "$scratch_dir/$sbe_binary_filename";
     $sections{PAYLOAD}{in}      = "$payload.bin";
@@ -404,7 +426,7 @@ if ($release ne "p8") {
 }
 else
 {
-    # Inject ECC into HBD (hostboot targeting) output binary
+    # Inject ECC into HBD_RO (hostboot targeting) output binary
     run_command("dd if=$op_target_dir/$targeting_binary_source of=$scratch_dir/$targeting_binary_source ibs=4k conv=sync");
     run_command("ecc --inject $scratch_dir/$targeting_binary_source --output $scratch_dir/$targeting_binary_filename --p8");
 


### PR DESCRIPTION
This commit adds the support to take the attribute/targeting "HBD"
PNOR Partition and split it up into two separate PNOR patitions:
HBD_RO ("READ-ONLY") and HBD_RW ("Read-Write").

RTC:200281
CQ:SW423354