### PR TITLE
PNOR: Add Support For Passing In Security Version Value

### DIFF
--- a/update_image.pl
+++ b/update_image.pl
@@ -43,6 +43,7 @@ my $ocmbfw_original_filename = "";
 my $ocmbfw_binary_filename = "";
 my $ocmbfw_version = "0.1"; #default value if none passed via command line
 my $ocmbfw_url = "http://www.ibm.com"; #default value if none passed via command line
+my $security_version = "";
 
 while (@ARGV > 0){
     $_ = $ARGV[0];
@@ -196,6 +197,10 @@ while (@ARGV > 0){
     elsif(/^-ocmbfw_url/i){
         # This is the url string for the ocmbfw
         $ocmbfw_url = $ARGV[1];
+        shift;
+    }
+    elsif (/^-security_version/i){
+        $security_version = $ARGV[1];
         shift;
     }
     else {
@@ -482,6 +487,9 @@ sub processConvergedSections {
         my $keyTransitionArg = $key_transition ne "" ? "--key-transition $key_transition" : "";
         # Determine which type of signing to use
         my $signModeArg = $sign_mode ne "" ? "--sign-mode $sign_mode" : "";
+        # Determine which type of security_version to use
+        my $securityVersionModeArg = $security_version ne "" ? "--secure-version $security_version" : "";
+
 
         # Process each image
         my $cmd =   "cd $scratch_dir && "
@@ -490,6 +498,7 @@ sub processConvergedSections {
                       . "--systemBinFiles $system_bin_files "
                       . "--pnorLayout $pnor_layout "
                       . "$securebootArg $keyTransitionArg $signModeArg "
+                      . "$securityVersionModeArg "
                       . "--hwKeyHashFile $hb_image_dir/imprintHwKeyHash";
 
         # Print context not visible in the actual command


### PR DESCRIPTION
This commit adds support for the udpate_image.pl script to take in
and use a security version paramater passed in from the op-build repo's
openpower-pnor.mk file.